### PR TITLE
Fix for single loc sub's completion firing repeatedly

### DIFF
--- a/FSQLocationBroker/FSQSingleLocationSubscriber.m
+++ b/FSQLocationBroker/FSQSingleLocationSubscriber.m
@@ -156,15 +156,17 @@
 }
 
 - (void)applicationDidEnterBackground:(NSNotification *)notification {
-    /**
-     NSNotificationCenter maintains non-strong references to objects. 
-     If it calls this method, when we stopListening later and remove ourself from the broker,
-     it is possible our retain count will immediately go to 0 mid-method execution if no one
-     else is retaining us, so we have to make sure we have a strong reference to ourself here
-     so we don't crash.
-     */
-    __typeof(self) strongSelf = self;
-    [strongSelf cutoffTimerFired:strongSelf.cutoffTimer];
+    if (self.isListening) {
+        /**
+         NSNotificationCenter maintains non-strong references to objects. 
+         If it calls this method, when we stopListening later and remove ourself from the broker,
+         it is possible our retain count will immediately go to 0 mid-method execution if no one
+         else is retaining us, so we have to make sure we have a strong reference to ourself here
+         so we don't crash.
+         */
+        __typeof(self) strongSelf = self;
+        [strongSelf cutoffTimerFired:strongSelf.cutoffTimer];
+    }
 }
 
 - (void)dealloc {


### PR DESCRIPTION
If you had a single location subscriber that ran in the background that you maintained a strong reference to, it's completion block could fire multiple times (on every background, since we didn't check the listening state there).