### PR TITLE
Only checking background options

### DIFF
--- a/FSQLocationBroker/FSQLocationBroker.m
+++ b/FSQLocationBroker/FSQLocationBroker.m
@@ -211,7 +211,7 @@ static Class sharedInstanceClass = nil;
     
     BOOL subscriberWantsBackgroundLocationUpdates = NO;
     for (NSObject<FSQLocationSubscriber> *locationSubscriber in self.locationSubscribers) {
-        if (subscriberWantsContinuousLocation(locationSubscriber) && subscriberShouldRunInBackground(locationSubscriber)) {
+        if (subscriberShouldRunInBackground(locationSubscriber)) {
             subscriberWantsBackgroundLocationUpdates = YES;
             break;
         }


### PR DESCRIPTION
Allowing us to be able to use Location Broker in background mode with non-continuous location updates (SLCs)